### PR TITLE
[WIP] Expand arithmetic API arguments

### DIFF
--- a/umbral/modbn.go
+++ b/umbral/modbn.go
@@ -240,7 +240,7 @@ func (m *ModBigNum) Invert(bn1 ModBigNum) error {
     return nil
 }
 
-func (m *ModBigNum) Neg() error {
+func (m *ModBigNum) Neg(bn1 ModBigNum) error {
     // Computes the modular opposite (i.e., additive inverse) of a BIGNUM
     zero := IntToBN(0)
     defer FreeBigNum(zero)
@@ -248,7 +248,7 @@ func (m *ModBigNum) Neg() error {
     ctx := C.BN_CTX_new()
     defer FreeBNCTX(ctx)
 
-    result := C.BN_mod_sub(m.Bignum, zero, m.Bignum, m.Curve.Order, ctx)
+    result := C.BN_mod_sub(m.Bignum, zero, bn1.Bignum, m.Curve.Order, ctx)
 
     if result != 1 {
         return errors.New("BN_mod_sub failure")

--- a/umbral/modbn.go
+++ b/umbral/modbn.go
@@ -257,13 +257,13 @@ func (m *ModBigNum) Neg(bn1 ModBigNum) error {
     return nil
 }
 
-func (m *ModBigNum) Mod(other ModBigNum) error {
+func (m *ModBigNum) Mod(bn1, modulus ModBigNum) error {
     rem := GetBigNum()
 
     bnCtx := C.BN_CTX_new()
     defer FreeBNCTX(bnCtx)
 
-    result := C.BN_nnmod(rem, m.Bignum, other.Bignum, bnCtx)
+    result := C.BN_nnmod(rem, bn1.Bignum, modulus.Bignum, bnCtx)
     if result != 1 {
         return errors.New("BN_nnmod failure")
     }

--- a/umbral/modbn.go
+++ b/umbral/modbn.go
@@ -149,7 +149,7 @@ func (m *ModBigNum) Pow(base, exp ModBigNum) error {
     return nil
 }
 
-func (m *ModBigNum) Mul(other ModBigNum) error {
+func (m *ModBigNum) Mul(bn1, bn2 ModBigNum) error {
     /*
     Performs a BN_mod_mul between two BIGNUMS.
     */
@@ -158,7 +158,7 @@ func (m *ModBigNum) Mul(other ModBigNum) error {
     bnCtx := C.BN_CTX_new()
     defer FreeBNCTX(bnCtx)
 
-    result := C.BN_mod_mul(product, m.Bignum, other.Bignum, m.Curve.Order, bnCtx)
+    result := C.BN_mod_mul(product, bn1.Bignum, bn2.Bignum, m.Curve.Order, bnCtx)
     if result != 1 {
         return errors.New("BN_mod_mul failure")
     }

--- a/umbral/modbn.go
+++ b/umbral/modbn.go
@@ -35,9 +35,11 @@ type ModBigNum struct {
 }
 
 func GetNewModBN(cNum BigNum, curve Curve) (ModBigNum, error) {
-    // Return the ModBigNum only if the provided Bignum is within the order of the curve.
-    if !BNIsWithinOrder(cNum, curve) {
-        return ModBigNum{}, errors.New("The provided BIGNUM is not on the provided curve.")
+    if cNum != nil {
+        // Return the ModBigNum only if the provided Bignum is within the order of the curve.
+        if !BNIsWithinOrder(cNum, curve) {
+            return ModBigNum{}, errors.New("The provided BIGNUM is not on the provided curve.")
+        }
     }
     return ModBigNum{Bignum: cNum, Curve: curve}, nil
 }

--- a/umbral/modbn.go
+++ b/umbral/modbn.go
@@ -188,13 +188,13 @@ func (m *ModBigNum) Div(bn1, bn2 ModBigNum) error {
     return nil
 }
 
-func (m *ModBigNum) Add(other ModBigNum) error {
+func (m *ModBigNum) Add(bn1, bn2 ModBigNum) error {
     sum := GetBigNum()
 
     bnCtx := C.BN_CTX_new()
     defer FreeBNCTX(bnCtx)
 
-    result := C.BN_mod_add(sum, m.Bignum, other.Bignum, m.Curve.Order, bnCtx)
+    result := C.BN_mod_add(sum, bn1.Bignum, bn2.Bignum, m.Curve.Order, bnCtx)
     if result != 1 {
         return errors.New("BN_mod_add failure")
     }

--- a/umbral/modbn.go
+++ b/umbral/modbn.go
@@ -26,7 +26,7 @@ import (
 
 /*
 Represents an OpenSSL BIGNUM modulo the order of a curve. Some of these
-operations will only work with prime numbers
+operations will only work with prime numbers TODO: which ones?
 */
 
 type ModBigNum struct {
@@ -123,7 +123,7 @@ func (m ModBigNum) Compare(other ModBigNum) int {
     return CompareBN(m.Bignum, other.Bignum)
 }
 
-func (m *ModBigNum) Pow(other ModBigNum) error {
+func (m *ModBigNum) Pow(base, exp ModBigNum) error {
     /*
     Performs a BN_mod_exp on two BIGNUMS.
     WARNING: Only in constant time if BN_FLG_CONSTTIME is set on the BN.
@@ -135,8 +135,9 @@ func (m *ModBigNum) Pow(other ModBigNum) error {
 
     bnMontCtx := TmpBNMontCTX(m.Curve.Order)
     defer FreeBNMontCTX(bnMontCtx)
-    result := C.BN_mod_exp_mont_consttime(power,
-        m.Bignum, other.Bignum, m.Curve.Order, bnCtx, bnMontCtx)
+
+    result := C.BN_mod_exp_mont_consttime(m.Bignum,
+        base.Bignum, exp.Bignum, m.Curve.Order, bnCtx, bnMontCtx)
 
     if result != 1 {
         return errors.New("BN_mod_exp failure")

--- a/umbral/modbn.go
+++ b/umbral/modbn.go
@@ -205,13 +205,13 @@ func (m *ModBigNum) Add(bn1, bn2 ModBigNum) error {
     return nil
 }
 
-func (m *ModBigNum) Sub(other ModBigNum) error {
+func (m *ModBigNum) Sub(bn1, bn2 ModBigNum) error {
     sub := GetBigNum()
 
     bnCtx := C.BN_CTX_new()
     defer FreeBNCTX(bnCtx)
 
-    result := C.BN_mod_sub(sub, m.Bignum, other.Bignum, m.Curve.Order, bnCtx)
+    result := C.BN_mod_sub(sub, bn1.Bignum, bn2.Bignum, m.Curve.Order, bnCtx)
     if result != 1 {
         return errors.New("BN_mod_sub failure")
     }

--- a/umbral/modbn.go
+++ b/umbral/modbn.go
@@ -169,13 +169,13 @@ func (m *ModBigNum) Mul(bn1, bn2 ModBigNum) error {
 }
 
 func (m *ModBigNum) Div(bn1, bn2 ModBigNum) error {
-    inv, err := bn2.Copy()
+    inv, err := GetNewModBN(nil, m.Curve)
     if err != nil {
         return err
     }
     defer inv.Free()
 
-    err = inv.Invert()
+    err = inv.Invert(bn2)
     if err != nil {
         return err
     }
@@ -222,13 +222,13 @@ func (m *ModBigNum) Sub(bn1, bn2 ModBigNum) error {
     return nil
 }
 
-func (m *ModBigNum) Invert() error {
+func (m *ModBigNum) Invert(bn1 ModBigNum) error {
     inverse := GetBigNum()
 
     bnCtx := C.BN_CTX_new()
     defer FreeBNCTX(bnCtx)
 
-    result := C.BN_mod_inverse(inverse, m.Bignum, m.Curve.Order, bnCtx)
+    result := C.BN_mod_inverse(inverse, bn1.Bignum, m.Curve.Order, bnCtx)
 
     if unsafe.Pointer(result) == C.NULL {
         return errors.New("BN_mod_inverse failure")

--- a/umbral/modbn.go
+++ b/umbral/modbn.go
@@ -168,19 +168,19 @@ func (m *ModBigNum) Mul(bn1, bn2 ModBigNum) error {
     return nil
 }
 
-func (m *ModBigNum) Div(other ModBigNum) error {
-    tmpBN, err := other.Copy()
+func (m *ModBigNum) Div(bn1, bn2 ModBigNum) error {
+    inv, err := bn2.Copy()
     if err != nil {
         return err
     }
-    defer tmpBN.Free()
+    defer inv.Free()
 
-    err = tmpBN.Invert()
+    err = inv.Invert()
     if err != nil {
         return err
     }
 
-    err = m.Mul(tmpBN)
+    err = m.Mul(bn1, inv)
     if err != nil {
         return err
     }

--- a/umbral/modbn_whitebox_test.go
+++ b/umbral/modbn_whitebox_test.go
@@ -378,13 +378,19 @@ func TestPow(t *testing.T) {
         }
         defer modbn2.Free()
 
+        power, err := GetNewModBN(nil, curve)
+        if err != nil {
+            t.Error(err)
+        }
+        defer power.Free()
+
         // 2^5 % curve.Order
-        err = modbn1.Pow(modbn2)
+        err = power.Pow(modbn1, modbn2)
         if err != nil {
             t.Error(err)
         }
 
-        t.Log(BNToDecStr(modbn1.Bignum))
+        t.Log(BNToDecStr(power.Bignum))
 
         goBN1 := big.NewInt(2)
         goBN2 := big.NewInt(5)
@@ -400,8 +406,8 @@ func TestPow(t *testing.T) {
         }
         defer modbn3.Free()
 
-        if !modbn1.Equals(modbn3) {
-            t.Error("modbn1 doesn't equal modbn3 which was converted from a Go big.Int")
+        if !power.Equals(modbn3) {
+            t.Error("power doesn't equal modbn3 which was converted from a Go big.Int")
         }
     })
     t.Run("big powers", func(t *testing.T) {
@@ -423,13 +429,19 @@ func TestPow(t *testing.T) {
         }
         defer modbn2.Free()
 
-        // 2^5 % curve.Order
-        err = modbn1.Pow(modbn2)
+        power, err := GetNewModBN(nil, curve)
+        if err != nil {
+            t.Error(err)
+        }
+        defer power.Free()
+
+        // 2^300 % curve.Order
+        err = power.Pow(modbn1, modbn2)
         if err != nil {
             t.Error(err)
         }
 
-        t.Log(BNToDecStr(modbn1.Bignum))
+        t.Log(BNToDecStr(power.Bignum))
 
         goBN1 := big.NewInt(2)
         goBN2 := big.NewInt(300)
@@ -445,8 +457,8 @@ func TestPow(t *testing.T) {
         }
         defer modbn3.Free()
 
-        if !modbn1.Equals(modbn3) {
-            t.Error("modbn1 doesn't equal modbn3 which was converted from a Go big.Int")
+        if !power.Equals(modbn3) {
+            t.Error("power doesn't equal modbn3 which was converted from a Go big.Int")
         }
     })
 }

--- a/umbral/modbn_whitebox_test.go
+++ b/umbral/modbn_whitebox_test.go
@@ -596,7 +596,13 @@ func TestSub(t *testing.T) {
     }
     defer modbn2.Free()
 
-    err = modbn1.Sub(modbn2)
+    diff, err := GetNewModBN(nil, curve)
+    if err != nil {
+        t.Error(err)
+    }
+    defer diff.Free()
+
+    err = diff.Sub(modbn1, modbn2)
     if err != nil {
         t.Error(err)
     }
@@ -607,8 +613,8 @@ func TestSub(t *testing.T) {
     }
     defer modbn3.Free()
 
-    if !modbn1.Equals(modbn3) {
-        t.Error("modbn1 doesn't equal modbn3: 768")
+    if !diff.Equals(modbn3) {
+        t.Error("diff doesn't equal modbn3: 768")
     }
 }
 

--- a/umbral/modbn_whitebox_test.go
+++ b/umbral/modbn_whitebox_test.go
@@ -555,7 +555,13 @@ func TestAdd(t *testing.T) {
     }
     defer modbn2.Free()
 
-    err = modbn1.Add(modbn2)
+    sum, err := GetNewModBN(nil, curve)
+    if err != nil {
+        t.Error(err)
+    }
+    defer sum.Free()
+
+    err = sum.Add(modbn1, modbn2)
     if err != nil {
         t.Error(err)
     }
@@ -566,8 +572,8 @@ func TestAdd(t *testing.T) {
     }
     defer modbn3.Free()
 
-    if !modbn1.Equals(modbn3) {
-        t.Error("modbn1 doesn't equal modbn3: 768")
+    if !sum.Equals(modbn3) {
+        t.Error("sum doesn't equal modbn3: 768")
     }
 }
 

--- a/umbral/modbn_whitebox_test.go
+++ b/umbral/modbn_whitebox_test.go
@@ -631,7 +631,13 @@ func TestInverse(t *testing.T) {
     }
     defer modbn.Free()
 
-    err = modbn.Invert()
+    inv, err := GetNewModBN(nil, curve)
+    if err != nil {
+        t.Error(err)
+    }
+    defer inv.Free()
+
+    err = inv.Invert(modbn)
     if err != nil {
         t.Error(err)
     }

--- a/umbral/modbn_whitebox_test.go
+++ b/umbral/modbn_whitebox_test.go
@@ -687,7 +687,13 @@ func TestMod(t *testing.T) {
     }
     defer modbn2.Free()
 
-    err = modbn1.Mod(modbn2)
+    remainder, err := GetNewModBN(nil, curve)
+    if err != nil {
+        t.Error(err)
+    }
+    defer remainder.Free()
+
+    err = remainder.Mod(modbn1, modbn2)
     if err != nil {
         t.Error(err)
     }

--- a/umbral/modbn_whitebox_test.go
+++ b/umbral/modbn_whitebox_test.go
@@ -643,6 +643,31 @@ func TestInverse(t *testing.T) {
     }
 }
 
+func TestNeg(t *testing.T) {
+    curve, err := GetNewCurve(SECP256K1)
+    if err != nil {
+        t.Error(err)
+    }
+    defer curve.Free()
+
+    modbn, err := Int2ModBN(512, curve)
+    if err != nil {
+        t.Error(err)
+    }
+    defer modbn.Free()
+
+    neg, err := GetNewModBN(nil, curve)
+    if err != nil {
+        t.Error(err)
+    }
+    defer neg.Free()
+
+    err = neg.Neg(modbn)
+    if err != nil {
+        t.Error(err)
+    }
+}
+
 func TestMod(t *testing.T) {
     curve, err := GetNewCurve(SECP256K1)
     if err != nil {

--- a/umbral/modbn_whitebox_test.go
+++ b/umbral/modbn_whitebox_test.go
@@ -524,7 +524,13 @@ func TestDiv(t *testing.T) {
     }
     defer modbn2.Free()
 
-    err = modbn1.Div(modbn2)
+    quotient, err := GetNewModBN(nil, curve)
+    if err != nil {
+        t.Error(err)
+    }
+    defer quotient.Free()
+
+    err = quotient.Div(modbn1, modbn2)
     if err != nil {
         t.Error(err)
     }

--- a/umbral/modbn_whitebox_test.go
+++ b/umbral/modbn_whitebox_test.go
@@ -482,8 +482,14 @@ func TestMul(t *testing.T) {
     }
     defer modbn2.Free()
 
-    // 2^5 % curve.Order
-    err = modbn1.Mul(modbn2)
+    product, err := GetNewModBN(nil, curve)
+    if err != nil {
+        t.Error(err)
+    }
+    defer product.Free()
+
+    // 2*300 % curve.Order
+    err = product.Mul(modbn1, modbn2)
     if err != nil {
         t.Error(err)
     }
@@ -494,8 +500,8 @@ func TestMul(t *testing.T) {
     }
     defer modbn3.Free()
 
-    if !modbn1.Equals(modbn3) {
-        t.Error("modbn1 doesn't equal modbn3: 600")
+    if !product.Equals(modbn3) {
+        t.Error("product doesn't equal modbn3: 600")
     }
 }
 

--- a/umbral/point.go
+++ b/umbral/point.go
@@ -249,13 +249,13 @@ func (m *Point) Mul(scalar ModBigNum, point Point) error {
     return nil
 }
 
-func (m *Point) Add(other Point) error {
+func (m *Point) Add(p1, p2 Point) error {
     // Performs an EC_POINT_add on two EC_POINTS.
 
     ctx := C.BN_CTX_new()
     defer FreeBNCTX(ctx)
 
-    result := C.EC_POINT_add(m.Curve.Group, m.ECPoint, m.ECPoint, other.ECPoint, ctx)
+    result := C.EC_POINT_add(m.Curve.Group, m.ECPoint, p1.ECPoint, p2.ECPoint, ctx)
     if result != 1 {
         return errors.New("EC_POINT_add failure")
     }

--- a/umbral/point.go
+++ b/umbral/point.go
@@ -228,11 +228,12 @@ func (m Point) Equals(other Point) (bool, error) {
     return result == 0, nil
 }
 
-func (m *Point) Mul(other ModBigNum) error {
+func (m *Point) Mul(scalar ModBigNum, point Point) error {
     /*
     Performs a EC_POINT_mul on an EC_POINT and a BIGNUM.
     */
-    if !m.Curve.Equals(other.Curve) {
+    // TODO: How do we check all three?
+    if !m.Curve.Equals(scalar.Curve) {
         return errors.New("The points do not share the same curve.")
     }
 
@@ -240,7 +241,7 @@ func (m *Point) Mul(other ModBigNum) error {
     defer FreeBNCTX(ctx)
 
     result := C.EC_POINT_mul(m.Curve.Group, m.ECPoint, (*C.BIGNUM)(C.NULL),
-        m.ECPoint, other.Bignum, ctx)
+        point.ECPoint, scalar.Bignum, ctx)
     if result != 1 {
         return errors.New("EC_POINT_mul failure")
     }

--- a/umbral/point.go
+++ b/umbral/point.go
@@ -39,18 +39,18 @@ type Point struct {
 func GetNewPoint(point ECPoint, curve Curve) (Point, error) {
     // Generate a new Point struct based on the arguments provided.
     //
-    // If point is nil then GetNewPoint will generate a new cryptographically secure
-    // ECPoint and check for errors before returning the new Point.
+    // If point is nil then GetNewPoint will give a null ECPoint
+    // and check for errors before returning the new Point.
     //
     // if point is nil AND the curve group is also nil then
     // GetNewPoint will fail and return the error.
     var err error = nil
     if point == nil {
-        newPoint, err := GenRandPoint(curve)
+        newPoint, err := GetNewECPoint(curve)
         if err != nil {
             return Point{}, err
         }
-        return newPoint, err
+        return Point{ECPoint: newPoint, Curve: curve}, err
     }
     return Point{ECPoint: point, Curve: curve}, err
 }

--- a/umbral/point.go
+++ b/umbral/point.go
@@ -263,20 +263,20 @@ func (m *Point) Add(p1, p2 Point) error {
     return nil
 }
 
-func (m *Point) Sub(other Point) error {
-    // Performs an subtraction on two EC_POINTS by adding by the inverse.
-    tmp, err := other.Copy()
+func (m *Point) Sub(p1, p2 Point) error {
+    // Performs a subtraction on two EC_POINTS by adding by the inverse.
+    inv, err := p2.Copy()
     if err != nil {
         return err
     }
-    defer tmp.Free()
+    defer inv.Free()
 
-    err = tmp.Invert()
+    err = inv.Invert()
     if err != nil {
         return err
     }
 
-    err = m.Add(tmp)
+    err = m.Add(p1, inv)
     if err != nil {
         return err
     }

--- a/umbral/point_whitebox_test.go
+++ b/umbral/point_whitebox_test.go
@@ -276,6 +276,12 @@ func TestPointSub(t *testing.T) {
     }
     defer curve.Free()
 
+    sum, err := GetNewPoint(nil, curve)
+    if err != nil {
+        t.Error(err)
+    }
+    defer sum.Free()
+
     point1, err := GenRandPoint(curve)
     if err != nil {
         t.Error(err)
@@ -288,7 +294,7 @@ func TestPointSub(t *testing.T) {
     }
     defer point2.Free()
 
-    err = point1.Sub(point2)
+    err = sum.Sub(point1, point2)
     if err != nil {
         t.Error(err)
     }

--- a/umbral/point_whitebox_test.go
+++ b/umbral/point_whitebox_test.go
@@ -230,6 +230,7 @@ func TestPointMul(t *testing.T) {
     if err != nil {
         t.Error(err)
     }
+    defer rG.Free()
 
     err = rG.Mul(r, G)
     if err != nil {
@@ -256,7 +257,13 @@ func TestPointAdd(t *testing.T) {
     }
     defer point2.Free()
 
-    err = point1.Add(point2)
+    sum, err := GetNewPoint(nil, curve)
+    if err != nil {
+        t.Error(err)
+    }
+    defer sum.Free()
+
+    err = sum.Add(point1, point2)
     if err != nil {
         t.Error(err)
     }

--- a/umbral/point_whitebox_test.go
+++ b/umbral/point_whitebox_test.go
@@ -217,19 +217,21 @@ func TestPointMul(t *testing.T) {
     }
     defer curve.Free()
 
-    point, err := GenRandPoint(curve)
+    G := GetGeneratorFromCurve(curve)
+    defer G.Free()
+
+    r, err := GenRandModBN(curve)
     if err != nil {
         t.Error(err)
     }
-    defer point.Free()
+    defer r.Free()
 
-    modbn, err := GenRandModBN(curve)
+    rG, err := GetNewPoint(nil, curve)
     if err != nil {
         t.Error(err)
     }
-    defer modbn.Free()
 
-    err = point.Mul(modbn)
+    err = rG.Mul(r, G)
     if err != nil {
         t.Error(err)
     }

--- a/umbral/point_whitebox_test.go
+++ b/umbral/point_whitebox_test.go
@@ -313,7 +313,13 @@ func TestPointInvert(t *testing.T) {
     }
     defer point.Free()
 
-    err = point.Invert()
+    invPoint, err := GetNewPoint(nil, curve)
+    if err != nil {
+        t.Error(err)
+    }
+    defer invPoint.Free()
+
+    err = invPoint.Invert(point)
     if err != nil {
         t.Error(err)
     }


### PR DESCRIPTION
### What this does:
1. Prevents the arithmetic API from modifying the class it's called with.[0]
2. Makes `GetNewPoint` to return a null ECPoint if a `nil` point is passed.
3. Makes `GetNewModBN` return a `ModBigNum` with a `nil` `BIGNUM`.
4. Adds a test for `ModBigNum.Neg`.

### What this needs:
1. Blackbox tests need to be fixed to comply with these API changes.

____

[0] -- The reason for this can be demonstrated in the following example. Let's imagine that we need to generate a pubkey.

With the way the API is _before_ this PR, it was as follows (somewhat pseudocode):
```
G := GetCurveGenerator(SECP256K1)
privkey := GenRand(SECP256K1)
G.Mul(privkey)
```

This can be fixed by doing `pubkey := G.Copy()`, but I don't think this is preferable.

This PR allows for the following (same scenario):
```
G := GetCurveGenerator(SECP256K1)
privkey := GenRand(SECP256K1)
pubkey := GetNewPoint(nil, curve)
pubkey.Mul(privkey, G)
```

Apologies for not catching this in review before @Karce. When looking at the logic between Python and Go, it made sense and looked similar. However, the bugs weren't apparent at the time until I tried to make some demo code. So, again, apologies for not catching this earlier. :(