### PR TITLE
Expand arithmetic API arguments

### DIFF
--- a/umbral/modbn.go
+++ b/umbral/modbn.go
@@ -128,7 +128,9 @@ func (m *ModBigNum) Pow(base, exp ModBigNum) error {
     Performs a BN_mod_exp on two BIGNUMS.
     WARNING: Only in constant time if BN_FLG_CONSTTIME is set on the BN.
     */
-    power := GetBigNum()
+    if m.Bignum == nil {
+        m.Bignum = GetBigNum()
+    }
 
     bnCtx := C.BN_CTX_new()
     defer FreeBNCTX(bnCtx)
@@ -142,10 +144,6 @@ func (m *ModBigNum) Pow(base, exp ModBigNum) error {
     if result != 1 {
         return errors.New("BN_mod_exp failure")
     }
-
-    FreeBigNum(m.Bignum)
-
-    m.Bignum = power
     return nil
 }
 
@@ -153,18 +151,16 @@ func (m *ModBigNum) Mul(bn1, bn2 ModBigNum) error {
     /*
     Performs a BN_mod_mul between two BIGNUMS.
     */
-    product := GetBigNum()
-
+    if m.Bignum == nil {
+        m.Bignum = GetBigNum()
+    }
     bnCtx := C.BN_CTX_new()
     defer FreeBNCTX(bnCtx)
 
-    result := C.BN_mod_mul(product, bn1.Bignum, bn2.Bignum, m.Curve.Order, bnCtx)
+    result := C.BN_mod_mul(m.Bignum, bn1.Bignum, bn2.Bignum, m.Curve.Order, bnCtx)
     if result != 1 {
         return errors.New("BN_mod_mul failure")
     }
-    FreeBigNum(m.Bignum)
-
-    m.Bignum = product
     return nil
 }
 
@@ -189,59 +185,57 @@ func (m *ModBigNum) Div(bn1, bn2 ModBigNum) error {
 }
 
 func (m *ModBigNum) Add(bn1, bn2 ModBigNum) error {
-    sum := GetBigNum()
+    if m.Bignum == nil {
+        m.Bignum = GetBigNum()
+    }
 
     bnCtx := C.BN_CTX_new()
     defer FreeBNCTX(bnCtx)
 
-    result := C.BN_mod_add(sum, bn1.Bignum, bn2.Bignum, m.Curve.Order, bnCtx)
+    result := C.BN_mod_add(m.Bignum, bn1.Bignum, bn2.Bignum, m.Curve.Order, bnCtx)
     if result != 1 {
         return errors.New("BN_mod_add failure")
     }
-
-    FreeBigNum(m.Bignum)
-
-    m.Bignum = sum
     return nil
 }
 
 func (m *ModBigNum) Sub(bn1, bn2 ModBigNum) error {
-    sub := GetBigNum()
+    if m.Bignum == nil {
+        m.Bignum = GetBigNum()
+    }
 
     bnCtx := C.BN_CTX_new()
     defer FreeBNCTX(bnCtx)
 
-    result := C.BN_mod_sub(sub, bn1.Bignum, bn2.Bignum, m.Curve.Order, bnCtx)
+    result := C.BN_mod_sub(m.Bignum, bn1.Bignum, bn2.Bignum, m.Curve.Order, bnCtx)
     if result != 1 {
         return errors.New("BN_mod_sub failure")
     }
-
-    FreeBigNum(m.Bignum)
-
-    m.Bignum = sub
     return nil
 }
 
 func (m *ModBigNum) Invert(bn1 ModBigNum) error {
-    inverse := GetBigNum()
+    if m.Bignum == nil {
+        m.Bignum = GetBigNum()
+    }
 
     bnCtx := C.BN_CTX_new()
     defer FreeBNCTX(bnCtx)
 
-    result := C.BN_mod_inverse(inverse, bn1.Bignum, m.Curve.Order, bnCtx)
+    result := C.BN_mod_inverse(m.Bignum, bn1.Bignum, m.Curve.Order, bnCtx)
 
     if unsafe.Pointer(result) == C.NULL {
         return errors.New("BN_mod_inverse failure")
     }
-
-    FreeBigNum(m.Bignum)
-
-    m.Bignum = inverse
     return nil
 }
 
 func (m *ModBigNum) Neg(bn1 ModBigNum) error {
     // Computes the modular opposite (i.e., additive inverse) of a BIGNUM
+    if m.Bignum == nil {
+        m.Bignum = GetBigNum()
+    }
+
     zero := IntToBN(0)
     defer FreeBigNum(zero)
 
@@ -258,19 +252,17 @@ func (m *ModBigNum) Neg(bn1 ModBigNum) error {
 }
 
 func (m *ModBigNum) Mod(bn1, modulus ModBigNum) error {
-    rem := GetBigNum()
+    if m.Bignum == nil {
+        m.Bignum = GetBigNum()
+    }
 
     bnCtx := C.BN_CTX_new()
     defer FreeBNCTX(bnCtx)
 
-    result := C.BN_nnmod(rem, bn1.Bignum, modulus.Bignum, bnCtx)
+    result := C.BN_nnmod(m.Bignum, bn1.Bignum, modulus.Bignum, bnCtx)
     if result != 1 {
         return errors.New("BN_nnmod failure")
     }
-
-    FreeBigNum(m.Bignum)
-
-    m.Bignum = rem
     return nil
 }
 

--- a/umbral/modbn.go
+++ b/umbral/modbn.go
@@ -35,9 +35,11 @@ type ModBigNum struct {
 }
 
 func GetNewModBN(cNum BigNum, curve Curve) (ModBigNum, error) {
-    // Return the ModBigNum only if the provided Bignum is within the order of the curve.
-    if !BNIsWithinOrder(cNum, curve) {
-        return ModBigNum{}, errors.New("The provided BIGNUM is not on the provided curve.")
+    if cNum != nil {
+        // Return the ModBigNum only if the provided Bignum is within the order of the curve.
+        if !BNIsWithinOrder(cNum, curve) {
+            return ModBigNum{}, errors.New("The provided BIGNUM is not on the provided curve.")
+        }
     }
     return ModBigNum{Bignum: cNum, Curve: curve}, nil
 }

--- a/umbral/modbn_blackbox_test.go
+++ b/umbral/modbn_blackbox_test.go
@@ -102,7 +102,7 @@ func TestModBNOperations(t *testing.T) {
 
         switch k.Op {
         case "Addition":
-            err = tmp1.Add(tmp2)
+            err = tmp1.Add(tmp1, tmp2)
             if err != nil {
                 t.Error(err)
             }
@@ -122,7 +122,7 @@ func TestModBNOperations(t *testing.T) {
                 t.Error("After adding, the modbns were not equal")
             }
         case "Subtraction":
-            err = tmp1.Sub(tmp2)
+            err = tmp1.Sub(tmp1, tmp2)
             if err != nil {
                 t.Error(err)
             }
@@ -142,7 +142,7 @@ func TestModBNOperations(t *testing.T) {
                 t.Error("After subtraction, the modbns were not equal")
             }
         case "Multiplication":
-            err = tmp1.Mul(tmp2)
+            err = tmp1.Mul(tmp1, tmp2)
             if err != nil {
                 t.Error(err)
             }
@@ -162,7 +162,7 @@ func TestModBNOperations(t *testing.T) {
                 t.Error("After multiplication, the modbns were not equal")
             }
         case "Division":
-            err = tmp1.Div(tmp2)
+            err = tmp1.Div(tmp1, tmp2)
             if err != nil {
                 t.Error(err)
             }
@@ -182,7 +182,7 @@ func TestModBNOperations(t *testing.T) {
                 t.Error("After division, the modbns were not equal")
             }
         case "Pow":
-            err = tmp1.Pow(tmp2)
+            err = tmp1.Pow(tmp1, tmp2)
             if err != nil {
                 t.Error(err)
             }
@@ -202,7 +202,7 @@ func TestModBNOperations(t *testing.T) {
                 t.Error("After exponentiating, the modbns were not equal")
             }
         case "Inversion":
-            err = tmp1.Invert()
+            err = tmp1.Invert(tmp1)
             if err != nil {
                 t.Error(err)
             }
@@ -222,7 +222,7 @@ func TestModBNOperations(t *testing.T) {
                 t.Error("After inverting, the modbns were not equal")
             }
         case "Neg":
-            err = tmp1.Neg()
+            err = tmp1.Neg(tmp1)
             if err != nil {
                 t.Error(err)
             }

--- a/umbral/modbn_whitebox_test.go
+++ b/umbral/modbn_whitebox_test.go
@@ -378,13 +378,19 @@ func TestPow(t *testing.T) {
         }
         defer modbn2.Free()
 
+        power, err := GetNewModBN(nil, curve)
+        if err != nil {
+            t.Error(err)
+        }
+        defer power.Free()
+
         // 2^5 % curve.Order
-        err = modbn1.Pow(modbn2)
+        err = power.Pow(modbn1, modbn2)
         if err != nil {
             t.Error(err)
         }
 
-        t.Log(BNToDecStr(modbn1.Bignum))
+        t.Log(BNToDecStr(power.Bignum))
 
         goBN1 := big.NewInt(2)
         goBN2 := big.NewInt(5)
@@ -400,8 +406,8 @@ func TestPow(t *testing.T) {
         }
         defer modbn3.Free()
 
-        if !modbn1.Equals(modbn3) {
-            t.Error("modbn1 doesn't equal modbn3 which was converted from a Go big.Int")
+        if !power.Equals(modbn3) {
+            t.Error("power doesn't equal modbn3 which was converted from a Go big.Int")
         }
     })
     t.Run("big powers", func(t *testing.T) {
@@ -423,13 +429,19 @@ func TestPow(t *testing.T) {
         }
         defer modbn2.Free()
 
-        // 2^5 % curve.Order
-        err = modbn1.Pow(modbn2)
+        power, err := GetNewModBN(nil, curve)
+        if err != nil {
+            t.Error(err)
+        }
+        defer power.Free()
+
+        // 2^300 % curve.Order
+        err = power.Pow(modbn1, modbn2)
         if err != nil {
             t.Error(err)
         }
 
-        t.Log(BNToDecStr(modbn1.Bignum))
+        t.Log(BNToDecStr(power.Bignum))
 
         goBN1 := big.NewInt(2)
         goBN2 := big.NewInt(300)
@@ -445,8 +457,8 @@ func TestPow(t *testing.T) {
         }
         defer modbn3.Free()
 
-        if !modbn1.Equals(modbn3) {
-            t.Error("modbn1 doesn't equal modbn3 which was converted from a Go big.Int")
+        if !power.Equals(modbn3) {
+            t.Error("power doesn't equal modbn3 which was converted from a Go big.Int")
         }
     })
 }
@@ -470,8 +482,14 @@ func TestMul(t *testing.T) {
     }
     defer modbn2.Free()
 
-    // 2^5 % curve.Order
-    err = modbn1.Mul(modbn2)
+    product, err := GetNewModBN(nil, curve)
+    if err != nil {
+        t.Error(err)
+    }
+    defer product.Free()
+
+    // 2*300 % curve.Order
+    err = product.Mul(modbn1, modbn2)
     if err != nil {
         t.Error(err)
     }
@@ -482,8 +500,8 @@ func TestMul(t *testing.T) {
     }
     defer modbn3.Free()
 
-    if !modbn1.Equals(modbn3) {
-        t.Error("modbn1 doesn't equal modbn3: 600")
+    if !product.Equals(modbn3) {
+        t.Error("product doesn't equal modbn3: 600")
     }
 }
 
@@ -506,7 +524,13 @@ func TestDiv(t *testing.T) {
     }
     defer modbn2.Free()
 
-    err = modbn1.Div(modbn2)
+    quotient, err := GetNewModBN(nil, curve)
+    if err != nil {
+        t.Error(err)
+    }
+    defer quotient.Free()
+
+    err = quotient.Div(modbn1, modbn2)
     if err != nil {
         t.Error(err)
     }
@@ -531,7 +555,13 @@ func TestAdd(t *testing.T) {
     }
     defer modbn2.Free()
 
-    err = modbn1.Add(modbn2)
+    sum, err := GetNewModBN(nil, curve)
+    if err != nil {
+        t.Error(err)
+    }
+    defer sum.Free()
+
+    err = sum.Add(modbn1, modbn2)
     if err != nil {
         t.Error(err)
     }
@@ -542,8 +572,8 @@ func TestAdd(t *testing.T) {
     }
     defer modbn3.Free()
 
-    if !modbn1.Equals(modbn3) {
-        t.Error("modbn1 doesn't equal modbn3: 768")
+    if !sum.Equals(modbn3) {
+        t.Error("sum doesn't equal modbn3: 768")
     }
 }
 
@@ -566,7 +596,13 @@ func TestSub(t *testing.T) {
     }
     defer modbn2.Free()
 
-    err = modbn1.Sub(modbn2)
+    diff, err := GetNewModBN(nil, curve)
+    if err != nil {
+        t.Error(err)
+    }
+    defer diff.Free()
+
+    err = diff.Sub(modbn1, modbn2)
     if err != nil {
         t.Error(err)
     }
@@ -577,8 +613,8 @@ func TestSub(t *testing.T) {
     }
     defer modbn3.Free()
 
-    if !modbn1.Equals(modbn3) {
-        t.Error("modbn1 doesn't equal modbn3: 768")
+    if !diff.Equals(modbn3) {
+        t.Error("diff doesn't equal modbn3: 768")
     }
 }
 
@@ -595,7 +631,38 @@ func TestInverse(t *testing.T) {
     }
     defer modbn.Free()
 
-    err = modbn.Invert()
+    inv, err := GetNewModBN(nil, curve)
+    if err != nil {
+        t.Error(err)
+    }
+    defer inv.Free()
+
+    err = inv.Invert(modbn)
+    if err != nil {
+        t.Error(err)
+    }
+}
+
+func TestNeg(t *testing.T) {
+    curve, err := GetNewCurve(SECP256K1)
+    if err != nil {
+        t.Error(err)
+    }
+    defer curve.Free()
+
+    modbn, err := Int2ModBN(512, curve)
+    if err != nil {
+        t.Error(err)
+    }
+    defer modbn.Free()
+
+    neg, err := GetNewModBN(nil, curve)
+    if err != nil {
+        t.Error(err)
+    }
+    defer neg.Free()
+
+    err = neg.Neg(modbn)
     if err != nil {
         t.Error(err)
     }
@@ -620,7 +687,13 @@ func TestMod(t *testing.T) {
     }
     defer modbn2.Free()
 
-    err = modbn1.Mod(modbn2)
+    remainder, err := GetNewModBN(nil, curve)
+    if err != nil {
+        t.Error(err)
+    }
+    defer remainder.Free()
+
+    err = remainder.Mod(modbn1, modbn2)
     if err != nil {
         t.Error(err)
     }

--- a/umbral/point.go
+++ b/umbral/point.go
@@ -205,6 +205,7 @@ func (m Point) ToBytes(isCompressed bool) ([]byte, error) {
 }
 
 func GetGeneratorFromCurve(curve Curve) Point {
+    // DO NOT free both the generator and the curve.
     // Consider making a copy of this point
     // so there are not any double frees.
     return Point{curve.Generator, curve}
@@ -380,7 +381,7 @@ func (m Point) Copy() (Point, error) {
     return Point{ECPoint: point, Curve: m.Curve}, nil
 }
 
-func (m Point) Free() {
+func (m *Point) Free() {
     FreeECPoint(m.ECPoint)
     // Do not free the curve.
     // m.Curve.Free()

--- a/umbral/point_blackbox_test.go
+++ b/umbral/point_blackbox_test.go
@@ -120,7 +120,7 @@ func TestPointOperations(t *testing.T) {
 
         switch k.Op {
         case "Addition":
-            err = tmp1.Add(tmp2)
+            err = tmp1.Add(tmp1, tmp2)
             if err != nil {
                 t.Error(err)
             }
@@ -144,7 +144,7 @@ func TestPointOperations(t *testing.T) {
                 t.Error("After adding, the points were not equal")
             }
         case "Subtraction":
-            err = tmp1.Sub(tmp2)
+            err = tmp1.Sub(tmp1, tmp2)
             if err != nil {
                 t.Error(err)
             }
@@ -169,7 +169,7 @@ func TestPointOperations(t *testing.T) {
                 t.Error("After subtraction, the points were not equal")
             }
         case "Multiplication":
-            err = tmp1.Mul(tmp4)
+            err = tmp1.Mul(tmp4, tmp1)
             if err != nil {
                 t.Error(err)
             }
@@ -194,7 +194,7 @@ func TestPointOperations(t *testing.T) {
                 t.Error("After multiplication, the points were not equal")
             }
         case "Inversion":
-            err = tmp1.Invert()
+            err = tmp1.Invert(tmp1)
             if err != nil {
                 t.Error(err)
             }

--- a/umbral/point_whitebox_test.go
+++ b/umbral/point_whitebox_test.go
@@ -218,7 +218,6 @@ func TestPointMul(t *testing.T) {
     defer curve.Free()
 
     G := GetGeneratorFromCurve(curve)
-    defer G.Free()
 
     r, err := GenRandModBN(curve)
     if err != nil {

--- a/umbral/point_whitebox_test.go
+++ b/umbral/point_whitebox_test.go
@@ -217,19 +217,22 @@ func TestPointMul(t *testing.T) {
     }
     defer curve.Free()
 
-    point, err := GenRandPoint(curve)
+    G := GetGeneratorFromCurve(curve)
+    defer G.Free()
+
+    r, err := GenRandModBN(curve)
     if err != nil {
         t.Error(err)
     }
-    defer point.Free()
+    defer r.Free()
 
-    modbn, err := GenRandModBN(curve)
+    rG, err := GetNewPoint(nil, curve)
     if err != nil {
         t.Error(err)
     }
-    defer modbn.Free()
+    defer rG.Free()
 
-    err = point.Mul(modbn)
+    err = rG.Mul(r, G)
     if err != nil {
         t.Error(err)
     }
@@ -254,7 +257,13 @@ func TestPointAdd(t *testing.T) {
     }
     defer point2.Free()
 
-    err = point1.Add(point2)
+    sum, err := GetNewPoint(nil, curve)
+    if err != nil {
+        t.Error(err)
+    }
+    defer sum.Free()
+
+    err = sum.Add(point1, point2)
     if err != nil {
         t.Error(err)
     }
@@ -266,6 +275,12 @@ func TestPointSub(t *testing.T) {
         t.Error(err)
     }
     defer curve.Free()
+
+    sum, err := GetNewPoint(nil, curve)
+    if err != nil {
+        t.Error(err)
+    }
+    defer sum.Free()
 
     point1, err := GenRandPoint(curve)
     if err != nil {
@@ -279,7 +294,7 @@ func TestPointSub(t *testing.T) {
     }
     defer point2.Free()
 
-    err = point1.Sub(point2)
+    err = sum.Sub(point1, point2)
     if err != nil {
         t.Error(err)
     }
@@ -298,7 +313,13 @@ func TestPointInvert(t *testing.T) {
     }
     defer point.Free()
 
-    err = point.Invert()
+    invPoint, err := GetNewPoint(nil, curve)
+    if err != nil {
+        t.Error(err)
+    }
+    defer invPoint.Free()
+
+    err = invPoint.Invert(point)
     if err != nil {
         t.Error(err)
     }


### PR DESCRIPTION
### What this does:
1. Prevents the arithmetic API from modifying the class it's called with.[0]
2. Makes `GetNewPoint` to return a null ECPoint if a `nil` point is passed.
3. Makes `GetNewModBN` return a `ModBigNum` with a `nil` `BIGNUM`.
4. Adds a test for `ModBigNum.Neg`.

### What this needs:
1. Blackbox tests need to be fixed to comply with these API changes.

____

[0] -- The reason for this can be demonstrated in the following example. Let's imagine that we need to generate a pubkey.

With the way the API is _before_ this PR, it was as follows (somewhat pseudocode):
```
G := GetCurveGenerator(SECP256K1)
privkey := GenRand(SECP256K1)
G.Mul(privkey)
```

This can be fixed by doing `pubkey := G.Copy()`, but I don't think this is preferable.

This PR allows for the following (same scenario):
```
G := GetCurveGenerator(SECP256K1)
privkey := GenRand(SECP256K1)
pubkey := GetNewPoint(nil, curve)
pubkey.Mul(privkey, G)
```

Apologies for not catching this in review before @Karce. When looking at the logic between Python and Go, it made sense and looked similar. However, the bugs weren't apparent at the time until I tried to make some demo code. So, again, apologies for not catching this earlier. :(